### PR TITLE
Go-CLI parity fixes for submit commands

### DIFF
--- a/scripts/p3-submit-MSA.pl
+++ b/scripts/p3-submit-MSA.pl
@@ -28,7 +28,7 @@ If a file to be uploaded already exists and this parameter is specified, it will
 
 =item --aligner
 
-The aligner to use for the MSA.  Valid values are C<Muscle> and C<Mafft>.  The default is C<Muscle>.
+The aligner to use for the MSA.  Valid values are C<Muscle>, C<Mafft>, and C<progressiveMauve>.  The default is C<Muscle>.
 
 =item --alphabet
 
@@ -68,7 +68,7 @@ use Bio::KBase::AppService::UploadSpec;
 
 use constant ALPHABET_TYPE => { 'dna' => 'feature_dna_fasta', 'protein' => 'feature_protein_fasta' };
 
-use constant ALIGNER => { 'Muscle' => 1, 'Mafft' => 1 };
+use constant ALIGNER => { 'Muscle' => 1, 'Mafft' => 1, 'progressiveMauve' => 1 };
 
 # Insure we're logged in.
 my $p3token = P3AuthToken->new();

--- a/scripts/p3-submit-genome-annotation.pl
+++ b/scripts/p3-submit-genome-annotation.pl
@@ -151,6 +151,9 @@ my($opt, $usage) =
 		     ["genetic-code|g=i", "Genetic code for this genome; either 11 or 4. If not specified defaults to 11 unless it can be determined from the declared or computed taxonomy ID."],
 		     ["domain|d=s", "Domain for this genome (Bacteria or Archaea)"],
 		     [],
+		     ["lowvan-min-contig-length=i", "Minimum contig length for the lowvan viral annotation pipeline (default 300)."],
+		     ["lowvan-max-contig-length=i", "Maximum contig length for the lowvan viral annotation pipeline (default 40000)."],
+		     [],
 		     ["Advanced options:"],
 		     [],
 		     ["workflow-file=s", "Use the given workflow document to process annotate this genome."],
@@ -344,6 +347,8 @@ my $params = {
     ($opt->reference_virus ? (reference_virus_name => $opt->reference_virus) : ()),
     ($opt->indexing_url ? (indexing_url => $opt->indexing_url) : ()),
     ($opt->public ? (public => 1) : ()),
+    (defined($opt->lowvan_min_contig_length) ? (lowvan_min_contig_length => $opt->lowvan_min_contig_length) : ()),
+    (defined($opt->lowvan_max_contig_length) ? (lowvan_max_contig_length => $opt->lowvan_max_contig_length) : ()),
 };
 
 my $start_params = {

--- a/scripts/p3-submit-genome-assembly.pl
+++ b/scripts/p3-submit-genome-assembly.pl
@@ -113,6 +113,7 @@ GetOptions("pilon-iter=i" => \ $params->{pilon_iter},
 	   "pipeline=s" => \ $params->{pipeline},
 	   "min-contig-len=i" => \ $params->{min_contig_len},
 	   "min-contig-cov=i" => \ $params->{min_contig_cov},
+	   "genome-size=s" => \ $params->{genome_size},
            'paired-end-lib=s{2}',  sub {
 	       my ($opt_name, $opt_value) = @_;
 	       


### PR DESCRIPTION
Small fixes to the `p3-submit-*` scripts to keep the Perl CLI aligned with the
Go SDK reimplementation (BV-BRC-Go-SDK), driven by the Go/Perl parity work.

## Changes

- **p3-submit-genome-annotation**: add `--lowvan-min-contig-length` and
  `--lowvan-max-contig-length` options, exposing the `lowvan_min_contig_length` /
  `lowvan_max_contig_length` parameters present in both the `GenomeAnnotation`
  and `GenomeAnnotationGenbank` app specs. Sent only when explicitly given so the
  service applies its own defaults (300 / 40000).
- **p3-submit-MSA**: add `progressiveMauve` to the accepted aligner list.
- **p3-submit-genome-assembly**: wire `--genome-size` into `GetOptions`.

## Verification

- `perl -c` passes on the modified scripts (with runtime PERL5LIB).
- `p3-submit-genome-annotation --dry-run` emits the new lowvan params, and the
  output was cross-checked to match the Go front-end's dry-run params exactly.